### PR TITLE
Updated regex and limited unsuccessful confirmation/login attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Contributors
 >> Harankumar Nallasivan, *Backend Spring Application*
 
+>> Ramaseshan Parthasarathy, *Backend Spring Application*
+
 >> Benjamin Yan, *Front-End React Native Application*
 
 ## Instructions
@@ -140,47 +142,19 @@ Make sure the MongoDB daemon is running.
         POST
     </td>
     <td>
-        username, confirmationCode
+        {
+            "username": "String",
+            "confirmationCode": "String"
+        }
     </td>
     <td>
-        <p>/api/public/confirmation?username=neo123&confirmationCode=2018</p>
+        {
+            "username": "neo123",
+            "confirmationCode": "2018"
+        }
     </td>
     <td>
         Unauthenticated
-    </td>
-</tr>
-<tr>
-    <td>
-        /api/user/set-name
-    </td>
-    <td>
-        POST
-    </td>
-    <td>
-        name
-    </td>
-    <td>
-        <p>/api/user/set-name?name=Thomas%20Anderson</p>
-    </td>
-    <td>
-        Authenticated
-    </td>
-</tr>
-<tr>
-    <td>
-        /api/user/set-nickname
-    </td>
-    <td>
-        POST
-    </td>
-    <td>
-        nickname
-    </td>
-    <td>
-        <p>/api/user/set-nickname?nickname=Neo</p>
-    </td>
-    <td>
-        Authenticated
     </td>
 </tr>
 </tbody>

--- a/src/main/java/com/rankenstein/services/controllers/UserController.java
+++ b/src/main/java/com/rankenstein/services/controllers/UserController.java
@@ -1,6 +1,5 @@
 package com.rankenstein.services.controllers;
 
-import com.rankenstein.services.models.User;
 import com.rankenstein.services.repositories.UserRepository;
 import com.rankenstein.services.services.UserService;
 import lombok.AccessLevel;
@@ -8,8 +7,6 @@ import lombok.experimental.FieldDefaults;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiresRoles("USER")
@@ -22,20 +19,4 @@ public class UserController {
 
     @Autowired
     UserService userService;
-
-    @RequestMapping(path = "/set-name", method = RequestMethod.POST)
-    public void setName(@RequestParam(name="name") String name) {
-        User user = userService.getActiveUser();
-        user.setName(name);
-        user.updateExpirationDate();
-        userRepository.save(user);
-    }
-
-    @RequestMapping(path = "/set-nickname", method = RequestMethod.POST)
-    public void setNickname(@RequestParam(name="nickname") String nickname) {
-        User user = userService.getActiveUser();
-        user.setNickname(nickname);
-        user.updateExpirationDate();
-        userRepository.save(user);
-    }
 }

--- a/src/main/java/com/rankenstein/services/exceptions/IncorrectConfirmationCodeException.java
+++ b/src/main/java/com/rankenstein/services/exceptions/IncorrectConfirmationCodeException.java
@@ -1,4 +1,13 @@
 package com.rankenstein.services.exceptions;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class IncorrectConfirmationCodeException extends Exception {
+    String username;
 }

--- a/src/main/java/com/rankenstein/services/formInput/ConfirmationForm.java
+++ b/src/main/java/com/rankenstein/services/formInput/ConfirmationForm.java
@@ -1,0 +1,17 @@
+package com.rankenstein.services.formInput;
+
+import com.rankenstein.services.validation.username.Username;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import javax.validation.constraints.NotEmpty;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConfirmationForm {
+    @Username
+    String username;
+    @NotEmpty
+    String confirmationCode;
+}

--- a/src/main/java/com/rankenstein/services/models/User.java
+++ b/src/main/java/com/rankenstein/services/models/User.java
@@ -18,18 +18,19 @@ import java.util.Set;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class User {
     public static final long TTL = 1000L*60*60*24*365;
+    public static final int BASE_ATTEMPTS_LEFT_FOR_LOGIN = 5;
+    public static final int BASE_ATTEMPTS_LEFT_FOR_CONFIRMATION = 3;
 
     @Id
     String id;
     String username;
     String hashedPasswordBase64;
     String passwordSalt;
-    String name;
-    String nickname;
     String email;
     String phoneNumber;
     Set<String> roles;
     Set<String> permissions;
+    int attemptsLeft;
 
     @Field
     @Indexed(name = "expirationDateIndex", expireAfterSeconds = 0)

--- a/src/main/java/com/rankenstein/services/validation/password/PasswordValidator.java
+++ b/src/main/java/com/rankenstein/services/validation/password/PasswordValidator.java
@@ -5,7 +5,7 @@ import javax.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 
 public class PasswordValidator implements ConstraintValidator<Password,String> {
-    private static Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9~!@#$%^&\\*]{8,}$");
+    private static Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9~!@#$%^&+=*\\-_\\\\]{8,}$");
     @Override
     public boolean isValid(String password, ConstraintValidatorContext constraintValidatorContext) {
         return password != null && PATTERN.matcher(password).matches();

--- a/src/main/java/com/rankenstein/services/validation/username/UsernameValidator.java
+++ b/src/main/java/com/rankenstein/services/validation/username/UsernameValidator.java
@@ -5,10 +5,10 @@ import javax.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 
 public class UsernameValidator implements ConstraintValidator<Username,String> {
-    private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9]{4,}$");
+    private static final Pattern PATTERN = Pattern.compile("^[_]{0,1}[a-zA-Z][_]{0,1}(?:[a-zA-Z\\d][_]{0,1})*$");
 
     @Override
     public boolean isValid(String username, ConstraintValidatorContext constraintValidatorContext) {
-        return username != null && PATTERN.matcher(username).matches();
+        return username != null && PATTERN.matcher(username).matches() && username.length() >= 5;
     }
 }

--- a/src/test/java/com/rankenstein/services/validation/password/PasswordValidatorTest.java
+++ b/src/test/java/com/rankenstein/services/validation/password/PasswordValidatorTest.java
@@ -15,7 +15,7 @@ public class PasswordValidatorTest extends PasswordValidator implements SimpleCo
     public String[] getValidTestCases() {
         return new String[] {
             /* contains all valid characters */
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*~",
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*~-_=+",
             "blahblah"
         };
     }

--- a/src/test/java/com/rankenstein/services/validation/username/UsernameValidatorTest.java
+++ b/src/test/java/com/rankenstein/services/validation/username/UsernameValidatorTest.java
@@ -16,7 +16,8 @@ public class UsernameValidatorTest extends UsernameValidator implements SimpleCo
         return new String[]{
             "blsfdsafd",
             "bwer234",
-            "Zdfsdf32"
+            "Zdfsdf32",
+            "_valid_number_of_underscores"
         };
     }
 
@@ -25,7 +26,8 @@ public class UsernameValidatorTest extends UsernameValidator implements SimpleCo
         return new String[]{
             "123sfsd",
             "sdf",
-            "dsafsa#@!"
+            "dsafsa#@!",
+            "__too_many_underscores_in___a_row"
         };
     }
 }


### PR DESCRIPTION
Changes

* Added Ram to the README.md as a contributor
* Fixed the regexes used for the `Username` and `Password` validators
* Removed `name` and `nickname` fields from `User`
* Changed the API signature of `/api/public/confirmation` to take parameters in the body rather than as URL parameters
* Added limit to the number of unsuccessful confirmation and login attempts
   * Now if you try to confirm for an unconfirmed username with a bad code 3 times, the unconfirmed user gets dropped
   * If you try to login with incorrect password 5 times, the account gets locked and can't log in again

